### PR TITLE
fix: LIKE Query for querying name of item to find

### DIFF
--- a/backend/src/main/java/com/auction/anabada/item/repository/ItemRepository.java
+++ b/backend/src/main/java/com/auction/anabada/item/repository/ItemRepository.java
@@ -51,9 +51,9 @@ public class ItemRepository {
 
     @Transactional(readOnly = true)
     public List<Item> findWithItemName(String includedName){
-        String sql = "select i from Item i where i.itemName LIKE :includedName";
+        String sql = "select i from Item i where i.itemName LIKE ?1";
         return em.createQuery(sql, Item.class)
-            .setParameter("includedName", "%" + includedName + "%")
+            .setParameter(1, includedName)
             .getResultList();
     }
 


### PR DESCRIPTION
## 진행 사항

- 기존에 상품명 조회 시 LIKE 쿼리에 대한 파라미터 전달 방식 변경 ( 지정 방식 -> 위치 기반 방식 )