### PR TITLE
feat: fix image process from encoding base64 to saving image file

### DIFF
--- a/backend/src/main/java/com/auction/anabada/biddetail/dto/DetailBidsDto.java
+++ b/backend/src/main/java/com/auction/anabada/biddetail/dto/DetailBidsDto.java
@@ -1,6 +1,6 @@
 package com.auction.anabada.biddetail.dto;
 
-//== 입찰 조회용(상) DTO ==//세
+//== 입찰 조회용(상세) DTO ==//
 
 import com.auction.anabada.user.domain.Category;
 import lombok.Builder;

--- a/backend/src/main/java/com/auction/anabada/biddetail/dto/SimpleBidsDto.java
+++ b/backend/src/main/java/com/auction/anabada/biddetail/dto/SimpleBidsDto.java
@@ -1,6 +1,9 @@
 package com.auction.anabada.biddetail.dto;
 
 import com.auction.anabada.user.domain.Category;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.sql.Blob;
 import java.time.LocalDateTime;
 import javax.persistence.Lob;
@@ -19,8 +22,7 @@ public class SimpleBidsDto {
     private String itemName;
     private Category category;
 
-    @Lob
-    private String itemImage;
+    private byte[] itemImage;
 
     private String lastAuctionDate;
 
@@ -30,16 +32,29 @@ public class SimpleBidsDto {
     private Boolean result;
 
     @Builder
-    public SimpleBidsDto(Long itemId,Long buyItemId,String itemName, Category category,String itemImage,
+    public SimpleBidsDto(Long itemId,Long buyItemId,String itemName, Category category,String itemPath,
         String lastAuctionDate,Long lastUserPrice,Long lastAuctionPrice,Boolean result) {
         this.itemId = itemId;
         this.buyItemId= buyItemId;
         this.itemName = itemName;
         this.category = category;
-        this.itemImage = itemImage;
+        this.itemImage = encodingFile(itemPath);
         this.lastAuctionDate = lastAuctionDate;
         this.lastUserPrice=lastUserPrice;
         this.lastAuctionPrice=lastAuctionPrice;
         this.result=result;
+    }
+
+    private byte[] encodingFile(String filePath){
+        InputStream imageStream = null;
+        byte[] imageByteArray = new byte[0];
+        try {
+            imageStream = new FileInputStream(filePath);
+            imageByteArray = imageStream.readAllBytes();
+            imageStream.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return imageByteArray;
     }
 }

--- a/backend/src/main/java/com/auction/anabada/biddetail/service/BidService.java
+++ b/backend/src/main/java/com/auction/anabada/biddetail/service/BidService.java
@@ -80,7 +80,7 @@ public class BidService {
                 .buyItemId(o.getBuyItemId())
                 .itemName(item.getItemName())
                 .category(item.getCategory())
-                .itemImage(item.getItemImage())
+                .itemPath(item.getImagePath())
                 .lastUserPrice(lastBidDetail.getBidCost())
                 .lastAuctionPrice(lastAuctionPrice)
                 .lastAuctionDate(lastTime)

--- a/backend/src/main/java/com/auction/anabada/item/api/ItemApiController.java
+++ b/backend/src/main/java/com/auction/anabada/item/api/ItemApiController.java
@@ -1,7 +1,6 @@
 package com.auction.anabada.item.api;
 
 import com.auction.anabada.item.domain.Item;
-import com.auction.anabada.item.dto.EnrollItemDto;
 import com.auction.anabada.item.dto.ItemDto;
 import com.auction.anabada.item.service.ItemService;
 import com.auction.anabada.search.dto.SearchDto;
@@ -10,7 +9,6 @@ import com.auction.anabada.user.domain.Category;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,25 +24,25 @@ public class ItemApiController {
 
     @ApiOperation(value="상품 조회", notes = "등록된 모든 상품을 조회한다.")
     @GetMapping("/api/item/all")
-    public List<EnrollItemDto> getAllItems(){
+    public List<ItemDto> getAllItems(){
         List<Item> items = itemService.findAll();
-        return items.stream().map(i -> new EnrollItemDto(i))
+        return items.stream().map(i -> new ItemDto(i))
             .collect(Collectors.toList());
     }
 
     @ApiOperation(value="카테고리 검색", notes = "선택한 카테고리 별로 상품을 조회한다. [~, ~] 안에 스트링 형태로 콤마로 구분하여 다중 선택이 가능하다.")
     @PostMapping("/api/item/category")
-    public List<EnrollItemDto> getItemByCategory(@RequestBody List<Category> categories){
+    public List<ItemDto> getItemByCategory(@RequestBody List<Category> categories){
         return itemService.findWithCategory(categories)
-            .stream().map(i -> new EnrollItemDto(i))
+            .stream().map(i -> new ItemDto(i))
             .collect(Collectors.toList());
     }
 
     @ApiOperation(value="상품 이름 검색", notes = "입력한 이름이 포함된 상품을 조회한다. 쌍따옴표 없는 스트링 형태로 상품 이름에 포함될 단어를 전송한다.")
     @PostMapping("/api/item/name")
-    public List<EnrollItemDto> getItemByName(@RequestBody String includedName){
+    public List<ItemDto> getItemByName(@RequestBody String includedName){
         return itemService.findWithItemName(includedName)
-            .stream().map(i -> new EnrollItemDto(i))
+            .stream().map(i -> new ItemDto(i))
             .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/auction/anabada/item/domain/Item.java
+++ b/backend/src/main/java/com/auction/anabada/item/domain/Item.java
@@ -33,8 +33,7 @@ public class Item {
     private LocalDateTime auctionStartDate;
     private LocalDateTime auctionEndDate;
 
-    @Lob @Basic(fetch = FetchType.EAGER)
-    private String itemImage;
+    private String imagePath;
 
     private Long interestCnt;
 
@@ -54,7 +53,7 @@ public class Item {
     public static Item createItem(EnrollItemDto enrollItemDto){
         Item item = new Item();
         item.itemName=enrollItemDto.getItemName();
-        item.itemImage=enrollItemDto.getItemImage();
+        item.imagePath=enrollItemDto.getImagePath();
         item.category=enrollItemDto.getCategory();
         item.auctionStartDate=LocalDateTime.parse(enrollItemDto.getAuctionStartDate(), DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         item.auctionEndDate=LocalDateTime.parse(enrollItemDto.getAuctionEndDate(), DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));

--- a/backend/src/main/java/com/auction/anabada/item/dto/EnrollItemDto.java
+++ b/backend/src/main/java/com/auction/anabada/item/dto/EnrollItemDto.java
@@ -1,17 +1,21 @@
 package com.auction.anabada.item.dto;
 
-
-import com.auction.anabada.item.domain.Item;
 import com.auction.anabada.user.domain.Category;
-import java.sql.Blob;
-import java.time.format.DateTimeFormatter;
-import javax.persistence.Lob;
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.UUID;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 
+//== 상품 등록용 DTO ==//
 @Data
 @NoArgsConstructor
+@Slf4j
 public class EnrollItemDto {
 
     private String itemName;
@@ -20,17 +24,30 @@ public class EnrollItemDto {
     private String auctionStartDate;
     private String auctionEndDate;
     private String description;
+    private MultipartFile imageFile;
+    private String imagePath;
 
-    @Lob
-    private String itemImage;
+    public void makeImagePath(String path) {
+        path = path + File.separator + "static" + File.separator + "images"; // 이미지 업로드 폴더 /resources/static/images
+        log.info("이미지 저장 경로 : " + path);
+        String fileName = UUID.randomUUID() + "";
+        String newPath = null;
 
-    public EnrollItemDto(Item item) {
-        this.itemName = item.getItemName();
-        this.category = item.getCategory();
-        this.lowerBoundPrice = item.getLowerBoundPrice();
-        this.auctionStartDate = item.getAuctionStartDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        this.auctionEndDate = item.getAuctionEndDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        this.itemImage = item.getItemImage();
-        this.description = item.getDescription();
+        if(imageFile.isEmpty()) { // 애초에 모든 물품은 사진 등록을 완료해야 함
+            // 여기로 들어오면 안됌
+            log.error("파일이 첨부되지 않았습니다.");
+            newPath = path + File.separator + "default.jpg";
+        } else { // 파일이 존재할 경우 정상 로직 수행
+            log.info("파일이 정상적으로 첨부되었습니다.");
+            File target = new File(path, fileName);
+            try {
+                FileCopyUtils.copy(imageFile.getBytes(), target);
+                newPath = path + File.separator + fileName;
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        log.info("파일이 저장된 경로 : " + newPath);
+        this.imagePath = newPath;
     }
 }

--- a/backend/src/main/java/com/auction/anabada/item/dto/ItemDto.java
+++ b/backend/src/main/java/com/auction/anabada/item/dto/ItemDto.java
@@ -2,13 +2,16 @@ package com.auction.anabada.item.dto;
 
 import com.auction.anabada.item.domain.Item;
 import com.auction.anabada.user.domain.Category;
-import java.sql.Blob;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.Lob;
 import lombok.Data;
 
+//== 상품 조회용 DTO ==//
 @Data
 public class ItemDto {
 
@@ -19,12 +22,11 @@ public class ItemDto {
     private Category category;
     private Long lowerBoundPrice;
     private Long currentPrice;
-    private LocalDateTime auctionStartDate;
-    private LocalDateTime auctionEndDate;
-
-    @Lob
-    private String itemImage;
+    private String auctionStartDate;
+    private String auctionEndDate;
     private Long interestCnt;
+    private String description;
+    private byte[] itemImage;
 
     public ItemDto(Item item) {
         this.itemId = item.getItemId();
@@ -32,9 +34,23 @@ public class ItemDto {
         this.category = item.getCategory();
         this.lowerBoundPrice = item.getLowerBoundPrice();
         this.currentPrice = item.getCurrentPrice();
-        this.auctionStartDate = item.getAuctionStartDate();
-        this.auctionEndDate = item.getAuctionEndDate();
-        this.itemImage = item.getItemImage();
+        this.auctionStartDate = item.getAuctionStartDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        this.auctionEndDate = item.getAuctionEndDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         this.interestCnt = item.getInterestCnt();
+        this.itemImage = encodingFile(item.getImagePath());
+        this.description = item.getDescription();
+    }
+
+    private byte[] encodingFile(String filePath){
+        InputStream imageStream = null;
+        byte[] imageByteArray = new byte[0];
+        try {
+            imageStream = new FileInputStream(filePath);
+            imageByteArray = imageStream.readAllBytes();
+            imageStream.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return imageByteArray;
     }
 }

--- a/backend/src/main/java/com/auction/anabada/saleItem/api/SaleItemApiController.java
+++ b/backend/src/main/java/com/auction/anabada/saleItem/api/SaleItemApiController.java
@@ -18,11 +18,11 @@ public class SaleItemApiController {
 
     @ApiOperation(value="물품등록",notes="2018-08-04 12:05:12 와 같은 형식으로 넣어줘야합니다.")
     @PostMapping("/api/saleItem/enrollItem")
-    public Long enrollItem(@RequestBody @Valid EnrollItemDto enrollItemDto,HttpServletRequest req){
+    public Long enrollItem(@RequestBody @Valid EnrollItemDto enrollItemDto, HttpServletRequest req){
         long userId = (Long)req.getSession().getAttribute("userId");
-
+        String uploadPath = req.getSession().getServletContext().getRealPath("/").concat("resources");
+        enrollItemDto.makeImagePath(uploadPath);
         return saleItemService.addSaleItem(userId,enrollItemDto);
     }
-
 
 }

--- a/backend/src/main/java/com/auction/anabada/user/api/UserApiController.java
+++ b/backend/src/main/java/com/auction/anabada/user/api/UserApiController.java
@@ -1,19 +1,15 @@
 package com.auction.anabada.user.api;
 
-import com.auction.anabada.biddetail.domain.BidDetail;
 import com.auction.anabada.biddetail.dto.DetailBidsDto;
 import com.auction.anabada.biddetail.dto.SimpleBidsDto;
 import com.auction.anabada.biddetail.service.BidService;
-import com.auction.anabada.item.domain.Item;
-import com.auction.anabada.item.dto.EnrollItemDto;
+import com.auction.anabada.item.dto.ItemDto;
 import com.auction.anabada.user.domain.User;
 import com.auction.anabada.user.dto.LoginRequestDto;
 import com.auction.anabada.user.dto.SignupRequestDto;
 import com.auction.anabada.user.dto.UserDto;
 import com.auction.anabada.user.service.UserService;
 import io.swagger.annotations.ApiOperation;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
@@ -97,7 +93,6 @@ public class UserApiController {
     public List<DetailBidsDto> getCurrentDetailBidDto(HttpServletRequest req,@RequestParam("buyItemId") Long buyItemId) {
 
         Long userId = (Long) req.getSession().getAttribute("userId");
-        User user = userService.findById(userId);
 
         List<DetailBidsDto> bidDetails = bidService.findBidDetails(userId, buyItemId);
 
@@ -109,7 +104,7 @@ public class UserApiController {
 
     @ApiOperation(value="개인별 등록 경매물품 조회", notes="자신이 등록한 모든 물품을 조회할 수 있다.")
     @GetMapping("/api/user/enrolledItems")
-    public List<EnrollItemDto> getEnrolledItems(HttpServletRequest req){
+    public List<ItemDto> getEnrolledItems(HttpServletRequest req){
         Long userId = (Long) req.getSession().getAttribute("userId");
         return userService.getEnrolledItems(userId);
     }

--- a/backend/src/main/java/com/auction/anabada/user/service/UserService.java
+++ b/backend/src/main/java/com/auction/anabada/user/service/UserService.java
@@ -1,6 +1,6 @@
 package com.auction.anabada.user.service;
 
-import com.auction.anabada.item.dto.EnrollItemDto;
+import com.auction.anabada.item.dto.ItemDto;
 import com.auction.anabada.user.domain.User;
 import com.auction.anabada.user.dto.LoginRequestDto;
 import com.auction.anabada.user.dto.UserDto;
@@ -90,10 +90,10 @@ public class UserService {
     }
 
     @Transactional
-    public List<EnrollItemDto> getEnrolledItems(Long userId) {
+    public List<ItemDto> getEnrolledItems(Long userId) {
         User user = userRepository.findById(userId);
         return user.getSaleItems().stream()
-            .map(o -> new EnrollItemDto(o.getItem()))
+            .map(o -> new ItemDto(o.getItem()))
             .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 문제 상황

 기존에 base64 방식의 인코딩은 조회/등록 속도가 너무 느렸음

## 진행 사항

-  물품 이미지 등록 방법 수정

    - 따라서 서버 resources/static/images 디렉토리에 이미지 파일 저장
    
    -  반환 시 해당 파일을 읽어서 byte 배열로 반환